### PR TITLE
fix(deps): add missing openai fallback libraries (#117)

### DIFF
--- a/src/mvt/requirements.txt
+++ b/src/mvt/requirements.txt
@@ -11,3 +11,6 @@ beautifulsoup4
 transformers
 fastapi
 uvicorn
+langchain-openai
+langchain-core
+openai


### PR DESCRIPTION
Fixes #117 

### Description
This PR resolves an issue where the OpenAI API fallback implementation was missing its required dependencies. 

### Changes Made
- Added `langchain-openai` to `src/mvt/requirements.txt`
- Added `langchain-core` to `src/mvt/requirements.txt`
- Added `openai` to `src/mvt/requirements.txt`

Tested locally to ensure the dependencies resolve correctly. 

@mergifyio queue